### PR TITLE
Only disable relevant warnings

### DIFF
--- a/recipes/crashpad_client/meta.cmake
+++ b/recipes/crashpad_client/meta.cmake
@@ -23,4 +23,11 @@ function(crashpad_client_add_to_build)
     set(CRASHPAD_CLIENT_GEN "${_recipe}/gen")
     set(CRASHPAD_CLIENT_ARCH "${_arch}")
     add_subdirectory("${_recipe}/build" "${CMAKE_BINARY_DIR}/_deps/crashpad_client-build")
+
+    if(MSVC)
+        target_compile_options(crashpad_client PRIVATE /wd4100)
+    else()
+        target_compile_options(crashpad_client PRIVATE -Wno-unused-parameter)
+    endif()
+
 endfunction()

--- a/recipes/liblouis/meta.cmake
+++ b/recipes/liblouis/meta.cmake
@@ -31,9 +31,10 @@ function(liblouis_post_resolve mode local_path os arch version)
     target_include_directories(liblouis PUBLIC ${_src} ${_gen})
     set_target_properties(liblouis PROPERTIES UNITY_BUILD OFF)
     if(MSVC)
-        target_compile_options(liblouis PRIVATE /W0)
+        target_compile_options(liblouis PRIVATE /wd4018 /wd4100 /wd4101 /wd4189 /wd4244 /wd4267 /wd4389 /wd4456 /wd4457 /wd4701 /wd4702 /wd4703 /wd4996)
     else()
-        target_compile_options(liblouis PRIVATE -w)
+        # equivalents for C4018 and C4389 might be needed
+        target_compile_options(liblouis PRIVATE -Wno-unused-parameter -Wno-unused-variable -Wno-conversion)
     endif()
 
     # expose tables for the consumer to install


### PR DESCRIPTION
Better the devil you know that the devil you don't...

Unfortunately we can't use `target_no_warnig(liblouis ...)`, as that is part of muse_framework, so we'd have to manually do it and separately for MSVC, gcc and clang.