### PR TITLE
Add rpath to shared libraries on *nix

### DIFF
--- a/buildtools/build_dependency.cmake
+++ b/buildtools/build_dependency.cmake
@@ -208,6 +208,62 @@ function(_bd_ensure_sonames os name install_dir)
     endforeach()
 endfunction()
 
+# Patch RPATH so a dep point to its sibling libraries
+function(_bd_relocatable_elf os name install_dir depends_prefixes)
+    if(os STREQUAL "windows" OR os STREQUAL "macos")
+        return()
+    endif()
+
+    if(NOT EXISTS "${install_dir}/lib")
+        return()
+    endif()
+
+    file(GLOB _shared_libs "${install_dir}/lib/*.so" "${install_dir}/lib/*.so.*")
+    if(NOT _shared_libs)
+        return()
+    endif()
+
+    find_program(PATCHELF NAMES patchelf)
+    if(NOT PATCHELF)
+        message(FATAL_ERROR "[${name}] patchelf not found")
+    endif()
+
+    get_filename_component(_install_lib "${install_dir}/lib" ABSOLUTE)
+    set(_rpath_entries "\$ORIGIN")
+    foreach(_prefix ${depends_prefixes})
+        if(EXISTS "${_prefix}/lib")
+            get_filename_component(_dep_lib "${_prefix}/lib" ABSOLUTE)
+            file(RELATIVE_PATH _rel "${_install_lib}" "${_dep_lib}")
+            list(APPEND _rpath_entries "\$ORIGIN/${_rel}")
+        endif()
+    endforeach()
+
+    list(REMOVE_DUPLICATES _rpath_entries)
+    list(JOIN _rpath_entries ":" _rpath)
+
+    foreach(_shared_lib ${_shared_libs})
+        if(IS_SYMLINK "${_shared_lib}")
+            continue()
+        endif()
+
+        execute_process(COMMAND "${PATCHELF}" --print-rpath "${_shared_lib}"
+                        OUTPUT_VARIABLE _current_rpath OUTPUT_STRIP_TRAILING_WHITESPACE
+                        ERROR_QUIET RESULT_VARIABLE _result)
+        if(NOT _result EQUAL 0)
+            continue()
+        endif()
+        if(_current_rpath STREQUAL _rpath)
+            continue()
+        endif()
+
+        execute_process(COMMAND "${PATCHELF}" --set-rpath "${_rpath}" "${_shared_lib}"
+                        RESULT_VARIABLE _result)
+        if(NOT _result EQUAL 0)
+            message(FATAL_ERROR "[${name}] patchelf failed for ${_shared_lib}")
+        endif()
+    endforeach()
+endfunction()
+
 # macOS: make installed dylibs relocatable.
 function(_bd_relocatable_macos os install_dir)
     if(NOT os STREQUAL "macos")
@@ -290,6 +346,7 @@ function(build_dep)
         if(_prev_sig STREQUAL "${_build_sig}")
             message(STATUS "[${BD_NAME}] up-to-date (recipe unchanged), skipping build")
             _bd_ensure_sonames("${BD_OS}" "${BD_NAME}" "${BD_INSTALL_DIR}")
+            _bd_relocatable_elf("${BD_OS}" "${BD_NAME}" "${BD_INSTALL_DIR}" "${BD_DEPENDS_PREFIXES}")
             _bd_relocatable_macos("${BD_OS}" "${BD_INSTALL_DIR}")
             return()
         endif()
@@ -388,6 +445,7 @@ function(build_dep)
 
     # Fix-up installed libraries
     _bd_ensure_sonames("${BD_OS}" "${BD_NAME}" "${INSTALL}")
+    _bd_relocatable_elf("${BD_OS}" "${BD_NAME}" "${INSTALL}" "${BD_DEPENDS_PREFIXES}")
     _bd_relocatable_macos("${BD_OS}" "${INSTALL}")
 
     # Record the build signature


### PR DESCRIPTION
Fixes deps reference system libraries instead of bundled

before

```
ldd src/app/mscore | grep libogg
        libogg.so.0 => /usr/lib/libogg.so.0 (0x00007f14d4346000)
```

after:
```
ldd src/app/mscore | grep libogg
        libogg.so.0 => /home/user/projects/build-MuseScoreStudio-Qt_6_10_2-Release/_deps/flac/lib/../../ogg/lib/libogg.so.0 (0x00007fba999c4000)
```