### PR TITLE
Add pipewire recipe

### DIFF
--- a/recipes/pipewire/build.cmake
+++ b/recipes/pipewire/build.cmake
@@ -1,0 +1,48 @@
+# PipeWire ships a Meson build, and muse_deps has no generic Meson helper
+# yet, so this recipe fetches Meson's own pinned source release (no system
+# pip install, so the build stays reproducible) and drives it directly.
+
+set(_meson_version 1.11.1)
+set(_meson_archive_name "meson-${_meson_version}.tar.gz")
+set(_meson_sha256 "6788ae299979643f8d841bcaf64352558436cae45a0355148a3aeeccf7913866")
+set(_meson_url "https://github.com/mesonbuild/meson/releases/download/${_meson_version}/${_meson_archive_name}")
+
+set(_meson_download_dir "${BD_CACHE}/downloads/meson")
+set(_meson_archive "${_meson_download_dir}/${_meson_archive_name}")
+if(EXISTS "${_meson_archive}")
+    file(SHA256 "${_meson_archive}" _got_sha256)
+    if(NOT _got_sha256 STREQUAL _meson_sha256)
+        message(FATAL_ERROR "[${BD_NAME}] cached ${_meson_archive_name} SHA256 mismatch: ${_got_sha256} != ${_meson_sha256}")
+    endif()
+else()
+    file(MAKE_DIRECTORY "${_meson_download_dir}")
+    _bd_fetch("${_meson_archive}" "${_meson_sha256}" "${_meson_url}")
+endif()
+
+set(_meson_root "${BD_WORK}/meson")
+file(MAKE_DIRECTORY "${_meson_root}")
+file(ARCHIVE_EXTRACT INPUT "${_meson_archive}" DESTINATION "${_meson_root}")
+set(_meson_py "${_meson_root}/meson-${_meson_version}/meson.py")
+
+find_program(PYTHON3 NAMES python3 REQUIRED)
+find_program(NINJA NAMES ninja REQUIRED)
+
+# Map the engine's CMake-style config onto a Meson buildtype
+if(BD_CONFIG STREQUAL "Debug")
+    set(_meson_buildtype debug)
+elseif(BD_CONFIG STREQUAL "MinSizeRel")
+    set(_meson_buildtype minsize)
+elseif(BD_CONFIG STREQUAL "Release")
+    set(_meson_buildtype release)
+else()
+    set(_meson_buildtype debugoptimized)
+endif()
+
+_bd_run(${PYTHON3} "${_meson_py}" setup "${BUILD}" "${SRC}"
+    --prefix "${INSTALL}"
+    --libdir lib
+    --buildtype "${_meson_buildtype}"
+    ${DEP_MESON_ARGS}
+)
+_bd_run(${PYTHON3} "${_meson_py}" compile -C "${BUILD}")
+_bd_run(${PYTHON3} "${_meson_py}" install -C "${BUILD}")

--- a/recipes/pipewire/meta.cmake
+++ b/recipes/pipewire/meta.cmake
@@ -1,0 +1,4 @@
+set(DEP_TARGET PipeWire::PipeWire)
+set(DEP_LIBS pipewire-0.3)
+set(DEP_INCLUDE_SUBDIRS pipewire-0.3 spa-0.2)
+set(DEP_SYSTEM_HEADER pipewire-0.3/pipewire/pipewire.h)

--- a/recipes/pipewire/spec.cmake
+++ b/recipes/pipewire/spec.cmake
@@ -1,0 +1,76 @@
+set(DEP_VERSION 1.6.7)
+
+set(DEP_SOURCE_URL    "https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/1.6.7/pipewire-1.6.7.tar.gz")
+set(DEP_SOURCE_SHA256 "a618c0a159055e2443f638c5c9f4b904e6902b655c09a7ff84546fa2447aedf8")
+
+# Consumed only as an optional Linux audio driver backend
+set(DEP_PLATFORMS linux-x86_64 linux-aarch64)
+
+# Built as a minimal client library: only the audioconvert/support spa
+# plugins that muse_audio_driver needs are enabled. Everything that would
+# pull in extra system deps (bluez5, jack, v4l2, gstreamer, session
+# managers, ...) is disabled so the build is deterministic across CI images.
+set(DEP_MESON_ARGS
+    -Ddocs=disabled
+    -Dman=disabled
+    -Dexamples=disabled
+    -Dtests=disabled
+    -Dinstalled_tests=disabled
+    -Dgstreamer=disabled
+    -Dgstreamer-device-provider=disabled
+    -Dlibsystemd=disabled
+    -Dlogind=disabled
+    -Dsystemd-system-service=disabled
+    -Dsystemd-user-service=disabled
+    -Dselinux=disabled
+    -Dpipewire-alsa=disabled
+    -Dpipewire-jack=disabled
+    -Dpipewire-v4l2=disabled
+    -Djack-devel=false
+    -Dalsa=disabled
+    -Daudiomixer=disabled
+    -Daudioconvert=enabled
+    -Dbluez5=disabled
+    -Dcontrol=disabled
+    -Daudiotestsrc=disabled
+    -Djack=disabled
+    -Dsupport=enabled
+    -Devl=disabled
+    -Dv4l2=disabled
+    -Ddbus=enabled
+    -Dlibcamera=disabled
+    -Dvideoconvert=disabled
+    -Dvideotestsrc=disabled
+    -Dpw-cat=disabled
+    -Dudev=disabled
+    -Dsdl2=disabled
+    -Dsndfile=disabled
+    -Dlibmysofa=disabled
+    -Dlibpulse=disabled
+    -Droc=disabled
+    -Davahi=disabled
+    -Decho-cancel-webrtc=disabled
+    -Dlibusb=disabled
+    -Dsession-managers=[]
+    -Draop=disabled
+    -Dlv2=disabled
+    -Dx11=disabled
+    -Dx11-xfixes=disabled
+    -Dlibcanberra=disabled
+    -Dlegacy-rtkit=false
+    -Davb=disabled
+    -Dflatpak=disabled
+    -Dreadline=disabled
+    -Dgsettings=disabled
+    -Dcompress-offload=disabled
+    -Drlimits-install=false
+    -Dopus=disabled
+    -Dlibffado=disabled
+    -Dgsettings-pulse-schema=disabled
+    -Debur128=disabled
+    -Dfftw=disabled
+    -Donnxruntime=disabled
+    -Dsnap=disabled
+)
+
+set(DEP_LICENSE_FILES COPYING)


### PR DESCRIPTION
Fetches PipeWire 1.6.7 and drives its Meson build directly (via a pinned,
sha256-verified Meson source release, no system pip install), producing a
minimal client-only libpipewire-0.3 for consumers that just need to talk to
a running PipeWire daemon. Linux-only (DEP_PLATFORMS linux-x86_64/aarch64).