### PR TITLE
Add libpng recipe, make freetype use it

### DIFF
--- a/recipes/freetype/spec.cmake
+++ b/recipes/freetype/spec.cmake
@@ -3,6 +3,8 @@ set(DEP_VERSION 2.14.1)
 set(DEP_SOURCE_URL    "https://download.savannah.gnu.org/releases/freetype/freetype-2.14.1.tar.xz")
 set(DEP_SOURCE_SHA256 "32427e8c471ac095853212a37aef816c60b42052d4d9e48230bab3bdf2936ccc")
 
+set(DEP_DEPENDS zlib libpng)
+
 set(DEP_CMAKE_ARGS
     -DBUILD_SHARED_LIBS=ON
     -DFT_DISABLE_ZLIB=TRUE

--- a/recipes/libpng/meta.cmake
+++ b/recipes/libpng/meta.cmake
@@ -1,0 +1,4 @@
+set(DEP_TARGET png::png)
+set(DEP_LIBS png16)
+set(DEP_LIBS_WINDOWS libpng16)
+set(DEP_SYSTEM_HEADER png.h)

--- a/recipes/libpng/patch/0001-cmake-universal-macos-prefer-neon.patch
+++ b/recipes/libpng/patch/0001-cmake-universal-macos-prefer-neon.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d91e3a6..0213dd6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -119,6 +119,11 @@ option(PNG_HARDWARE_OPTIMIZATIONS "Enable hardware optimizations" ON)
+ # in a single CMake invocation.
+ if(APPLE AND CMAKE_OSX_ARCHITECTURES)
+   string(TOLOWER "${CMAKE_OSX_ARCHITECTURES}" PNG_TARGET_ARCHITECTURE)
++  list(LENGTH CMAKE_OSX_ARCHITECTURES PNG_OSX_ARCH_COUNT)
++  if(PNG_OSX_ARCH_COUNT GREATER 1)
++    set(PNG_UNIVERSAL_APPLE ON)
++    set(PNG_TARGET_ARCHITECTURE "arm64")
++  endif()
+ else()
+   string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" PNG_TARGET_ARCHITECTURE)
+ endif()
+@@ -182,7 +187,7 @@ if(PNG_HARDWARE_OPTIMIZATIONS)
+           arm/arm_init.c
+           arm/filter_neon_intrinsics.c
+           arm/palette_neon_intrinsics.c)
+-      if(PNG_ARM_NEON STREQUAL "on")
++      if(PNG_ARM_NEON STREQUAL "on" AND NOT PNG_UNIVERSAL_APPLE)
+         add_definitions(-DPNG_ARM_NEON_OPT=2)
+       elseif(PNG_ARM_NEON STREQUAL "check")
+         add_definitions(-DPNG_ARM_NEON_CHECK_SUPPORTED)

--- a/recipes/libpng/spec.cmake
+++ b/recipes/libpng/spec.cmake
@@ -1,0 +1,22 @@
+set(DEP_VERSION 1.6.50)
+
+set(DEP_SOURCE_URL    "https://download.sourceforge.net/libpng/libpng-1.6.50.tar.xz")
+set(DEP_SOURCE_SHA256 "4df396518620a7aa3651443e87d1b2862e4e88cad135a8b93423e01706232307")
+
+set(DEP_DEPENDS zlib)
+
+set(DEP_CMAKE_ARGS
+    -DPNG_SHARED=ON
+    -DPNG_STATIC=OFF
+    -DPNG_FRAMEWORK=OFF
+    -DPNG_TESTS=OFF
+    -DPNG_TOOLS=OFF
+)
+
+# libpng 1.6 is not universal binary compatible
+# here we make it prefer arm optimizations instead of intel's
+# this is fixed in upcoming 1.8, but not in 1.6
+# https://github.com/pnggroup/libpng/issues/372
+set(DEP_PATCHES patch/0001-cmake-universal-macos-prefer-neon.patch)
+
+set(DEP_LICENSE_FILES LICENSE)


### PR DESCRIPTION
Adds libpng dependency


In macos universal binaries SIMD is disabled for intel part, because their current build setup does not allow to have both:
 https://github.com/pnggroup/libpng/issues/372